### PR TITLE
Option to rerun b-tagging

### DIFF
--- a/src/data/delphes/convert_to_h5.py
+++ b/src/data/delphes/convert_to_h5.py
@@ -235,14 +235,14 @@ def get_datasets(arrays, n_higgs, rerun_btagging):  # noqa: C901
     h1_pt, bh1_pt = H_pt[:, 0], H_pt[:, 0]
     h2_pt, bh2_pt = H_pt[:, 1], H_pt[:, 1]
     h3_pt, bh3_pt = H_pt[:, 2], H_pt[:, 2]
-    
+
     # add H mass info
     H_mh = higgses[mask_minjets].mass
     H_mh = ak.fill_none(ak.pad_none(H_mh, target=3, axis=1, clip=True), -1)
 
-    h1_mh, bh1_mh = H_mh[:,0], H_mh[:,0]
-    h2_mh, bh2_mh = H_mh[:,1], H_mh[:,1]
-    h3_mh, bh3_mh = H_mh[:,2], H_mh[:,2]
+    h1_mh, bh1_mh = H_mh[:, 0], H_mh[:, 0]
+    h2_mh, bh2_mh = H_mh[:, 1], H_mh[:, 1]
+    h3_mh, bh3_mh = H_mh[:, 2], H_mh[:, 2]
 
     # mask to define zero-padded small-radius jets
     mask = pt > MIN_JET_PT


### PR DESCRIPTION
- [x] add option to rerun b-tagging with UParT efficiencies based on CMS-DP-2024-066 (https://cds.cern.ch/record/2904702)
- [x] add option to use previous values based on CSV [arXiv:1211.4462] with values from https://github.com/delphes/delphes/blob/98f15add056e657e39bda9e32ccd97ef427ce04c/cards/delphes_card_CMS.tcl#L713-L736

@billy000400 please check to make sure you understand the code and it is correct / has no bugs. Plot the formulas and compare to the DP note. Test it, and if everything looks good, then merge it.

cc: @mstamenk @cmantill